### PR TITLE
Allow the Default watcher to track symlink creation/deletion

### DIFF
--- a/lib/File/ChangeNotify/Watcher.pm
+++ b/lib/File/ChangeNotify/Watcher.pm
@@ -163,8 +163,6 @@ sub _entry_for_map {
     # -d.
     my @stat = stat;
 
-    return if -l $path && !$is_dir;
-
     unless ($is_dir) {
         my $filter = $self->filter;
         return unless ( File::Spec->splitpath($path) )[2] =~ /$filter/;


### PR DESCRIPTION
The default watcher did not track the creation and deletion of symlinks, which was explicitly excluded for some reason.  This patch removes that exclusion